### PR TITLE
(QA-2095) Source ~/.profile

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,6 +147,13 @@ class profile_chruby (
     require => User[$username],
   }
 
+  # ensure that .profile and .bashrc are sourced
+  # .profile should be first
+  # .bashrc should be last
+  exec {  "grep -q -F '.profile' ${home}/.bash_profile || echo 'if [ -f \"\${HOME}/.profile\" ] ; then\n  source \"\${HOME}/.bashrc\"\nfi' > /tmp/bash_profile && cat ${home}/.bash_profile >> /tmp/bash_profile && mv /tmp/bash_profile ${home}/.bash_profile":
+    require => File["${home}/.bash_profile"],
+  }
+  ->
   exec {  "grep -q -F '.bashrc' ${home}/.bash_profile || echo 'if [ -f \"\${HOME}/.bashrc\" ] ; then\n  source \"\${HOME}/.bashrc\"\nfi' >> ${home}/.bash_profile":
     require => File["${home}/.bash_profile"],
   }


### PR DESCRIPTION
This commit ensures that `~/.profile` is sourced in
`.bash_profile`. Prior to this commit, if you were previously
using `.profile` and not `.bash_profile` then this installation
would cause any entries in `.profile` to be ignored because.
